### PR TITLE
Use global markdown loader for chapter 14

### DIFF
--- a/content/chapter14.html
+++ b/content/chapter14.html
@@ -21,36 +21,34 @@
   <!-- Seção 14.1 -->
   <section class="card" id="ch14-1">
     <h2 class="text-2xl font-semibold mb-2">14.1 Funções empresariais</h2>
-    <div data-md-src="chapter-14/14-1-business-roles.md"></div>
+    <div data-md-src="content/chapter-14/14-1-business-roles.md"></div>
   </section>
 
   <!-- Seção 14.2 -->
   <section class="card" id="ch14-2">
     <h2 class="text-2xl font-semibold mb-2">14.2 Preparação para a divulgação</h2>
-    <div data-md-src="chapter-14/14-2-preparing-for-disclosure.md"></div>
+    <div data-md-src="content/chapter-14/14-2-preparing-for-disclosure.md"></div>
   </section>
 
   <!-- Seção 14.3 -->
   <section class="card" id="ch14-3">
     <h2 class="text-2xl font-semibold mb-2">14.3 Dados de qualidade</h2>
-    <div data-md-src="chapter-14/14-3-preparing-quality-data.md"></div>
+    <div data-md-src="content/chapter-14/14-3-preparing-quality-data.md"></div>
   </section>
 
   <!-- Seção 14.4 -->
   <section class="card" id="ch14-4">
     <h2 class="text-2xl font-semibold mb-2">14.4 Comunicação de dados materiais</h2>
-    <div data-md-src="chapter-14/14-4-reporting-material-sustainability-data.md"></div>
+    <div data-md-src="content/chapter-14/14-4-reporting-material-sustainability-data.md"></div>
   </section>
 
   <!-- Seção 14.5 -->
   <section class="card" id="ch14-5">
     <h2 class="text-2xl font-semibold mb-2">14.5 Gestão do desempenho</h2>
-    <div data-md-src="chapter-14/14-5-managing-sustainability-performance.md"></div>
+    <div data-md-src="content/chapter-14/14-5-managing-sustainability-performance.md"></div>
   </section>
 </section>
 
-<!-- Carrega o script do leitor de Markdown -->
-<script src="../js/md-loader.js"></script>
 
 <!-- Estilo local para os cards -->
 <style>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
         </main>
     </div>
 
+    <script src="js/md-loader.js"></script>
+
     <script src="js/main.js"></script> <!-- Link para o JavaScript -->
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -78,6 +78,14 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!response.ok) throw new Error(`Content not found for ${pageId}`);
             
             contentContainer.innerHTML = await response.text();
+
+            if (window.renderMarkdownContainers) {
+                try {
+                    await window.renderMarkdownContainers(contentContainer);
+                } catch (mdError) {
+                    console.error('Failed to render markdown:', mdError);
+                }
+            }
             
             saveProgress(pageId);
             renderNav(pageId);
@@ -85,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
         } catch (error) {
             console.error('Failed to load content:', error);
-            contentContainer.innerHTML = `<p class="p-8 text-red-500">Error loading content. Please check the console.</p>`;
+            contentContainer.innerHTML = `<p class="p-8 text-red-500">Error loading content: ${error.message}</p>`;
         }
     };
 


### PR DESCRIPTION
## Summary
- Expose a single markdown loader and renderer via `window.renderMarkdownContainers`.
- Load the markdown renderer globally and invoke it after SPA page injection.
- Convert Chapter 14 HTML to use site-relative markdown paths and rely on the global loader.
- Await markdown rendering and log renderer failures for clearer error messages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef81e8348327b38f3b0d9a399a9a